### PR TITLE
BACKEND-18: Add Docker and docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.25.0-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o main ./cmd/server
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/main .
+
+EXPOSE 8080
+
+CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,68 @@
 # Backend (Gin + Swagger)
 
-## Быстрый старт
+## Подготовка окружения
 
-### Запуск сервера
+Перед запуском необходимо создать файл .env с переменными окружения.
+
+Скопируйте пример конфигурации командой
+
+    cp .env.example .env
+
+При необходимости отредактируйте значения.
+
+
+## Запуск Gin сервера и инфраструктуры
+
+    docker compose up --build
+
+После запуска будут подняты:
+- Backend (Gin сервер)
+- PostgreSQL
+- MinIO
+
+Backend будет доступен на http://localhost:8080
+
+
+## Локальный запуск Gin сервера
 
     go run cmd/server/main.go
-Сервер будет слушать на :8080.
 
-### Swagger UI
-Доступен по адресу http://localhost:8080/swagger/index.html. \
-Генерация документации после изменений в комментариях:
+Сервер будет слушать на http://localhost:8080
+
+
+## Миграции базы данных
+
+Команда выполняется один раз при первом запуске проекта или после сброса данных PostgreSQL.
+
+Установка migrate:
+
+    go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+
+Применение миграций (строка подключения зависит от переменных окружения):
+
+    migrate -path migrations -database "postgres://postgres:postgres@localhost:5432/skin_service?sslmode=disable" up
+
+
+## Swagger UI
+
+Swagger доступен по адресу http://localhost:8080/swagger/index.html
+
+Генерация документации:
 
     swag init -g cmd/server/main.go
+
+
+## Полезные команды
+
+Пересборка Docker:
+
+    docker compose down
+    docker compose up --build
+
+Запуск Docker:
+
+    docker compose up
+
+Полный сброс данных (PostgreSQL + MinIO):
+
+    docker compose down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: skin-service-backend
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      POSTGRES_HOST: postgres
+    extra_hosts:
+      - "localhost:host-gateway"
+    networks:
+      - skin-service-network
+
+  postgres:
+    image: postgres:17-alpine
+    container_name: skin-service-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - skin-service-network
+
+  minio:
+    image: minio/minio:latest
+    container_name: skin-service-minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    networks:
+      - skin-service-network
+
+volumes:
+  postgres_data:
+  minio_data:
+
+networks:
+  skin-service-network:
+    driver: bridge


### PR DESCRIPTION
Контейнеризован backend-сервис и настроено docker-compose окружение:

- Добавлен Dockerfile для сборки и запуска backend-сервиса.
- Настроен docker-compose для запуска backend-сервиса, PostgreSQL и MinIO.
- Обновлён README.md с инструкцией по запуску проекта.

Closes: #18 